### PR TITLE
fix: Process not exit Unity project

### DIFF
--- a/src/modules/unity.ts
+++ b/src/modules/unity.ts
@@ -57,9 +57,15 @@ export const createUnityProject = async (unityPath: string, projectPath: string)
 }
 
 export const openUnityProject = async (unityPath: string, projectPath: string) => {
-  await execa(unityPath, ["-projectPath", projectPath], {
-    stdio: "ignore",
+  const subprocess = execa(unityPath, ["-projectPath", projectPath], {
     detached: true,
-    cleanup: false,
+    cleanup: false, 
+    stdio: "ignore",
   });
+
+  // Waits for a short period of time before deeming the command successful
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+
+  // Disassociate the Unity process from the script process
+  subprocess.unref();
 }


### PR DESCRIPTION
Ao executar o script para criar e abrir um projeto Unity, o script não encerra corretamente e continua em execução até que o Unity seja fechado. Isso ocorre porque o processo do Unity é iniciado como um processo filho do script, e o `execa` espera que ele seja concluído antes de prosseguir.

## Solução proposta:

Modificar a função `openUnityProject` da seguinte maneira:

```javascript
export const openUnityProject = async (unityPath: string, projectPath: string) => {
  const subprocess = execa(unityPath, ["-projectPath", projectPath], {
    detached: true,
    cleanup: false, 
    stdio: "ignore",
  });

  // Waits for a short period of time before deeming the command successful
  await new Promise((resolve) => setTimeout(resolve, 2000));

  // Disassociate the Unity process from the script process
  subprocess.unref();
};
```

closes #8

## Execa Referencias 
> [child process](https://nodejs.org/api/child_process.html#optionsdetached)
> [unref](https://nodejs.org/api/child_process.html#childprocess_child_unref)